### PR TITLE
Fix wrong schema

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 4

--- a/libavm/docs_src/conf.py
+++ b/libavm/docs_src/conf.py
@@ -17,7 +17,7 @@ import os.path
 def read_version():
     try:
         return open(os.path.join(os.path.pardir,'VERSION'), 'r').readline().strip()
-    except IOError, e:
+    except IOError as e:
         raise SystemExit(
             "Error: you must run setup from the root directory (%s)" % str(e))
 

--- a/libavm/libavm/__init__.py
+++ b/libavm/libavm/__init__.py
@@ -30,6 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE
 
 
+from __future__ import print_function
 from libavm import *
 from libavm.specs import *
 from libavm.core import *
@@ -37,4 +38,4 @@ from libavm.core import *
 try:
     import libxmp
 except ImportError:
-    print "The Python AVM Library requires the Python XMP Toolkit"
+    print("The Python AVM Library requires the Python XMP Toolkit")

--- a/libavm/libavm/core.py
+++ b/libavm/libavm/core.py
@@ -33,6 +33,7 @@
 A module for parsing, manipulating, and serializing AVM data in the XMP format.
 """
 
+from future.utils import raise_
 try:
 	import libxmp
 except ImportError:
@@ -97,7 +98,7 @@ class AVMMeta(object):
 			if avmdt.set_data(self.xmp, value):
 				self.data[key] = avmdt.get_data(self.xmp)
 		else:
-			raise KeyError, "The key '%s' is not an AVM field" % key
+			raise_(KeyError, "The key '%s' is not an AVM field" % key)
 	
 	def __getitem__(self, key):
 		
@@ -105,7 +106,7 @@ class AVMMeta(object):
 			avmdt = self.specs[key]
 			return avmdt.get_data(self.xmp)
 		else:
-			raise KeyError, "The key '%s' is not an AVM field" % key
+			raise_(KeyError, "The key '%s' is not an AVM field" % key)
 	
 	def __delitem__(self, key):
 		
@@ -125,6 +126,6 @@ class AVMMeta(object):
 			avmdt = self.specs[key]
 			return avmdt.to_string(self.xmp)
 		else:
-			raise KeyError, "The key '%s' is not an AVM field" % key
+			raise_(KeyError, "The key '%s' is not an AVM field" % key)
 
 

--- a/libavm/libavm/datatypes.py
+++ b/libavm/libavm/datatypes.py
@@ -5,19 +5,19 @@
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 #	  * Redistributions of source code must retain the above copyright
 #		notice, this list of conditions and the following disclaimer.
-# 
+#
 #	  * Redistributions in binary form must reproduce the above copyright
 #		notice, this list of conditions and the following disclaimer in the
 #		documentation and/or other materials provided with the distribution.
-# 
-#	  * Neither the name of the European Space Agency, European Southern 
-#		Observatory nor the names of its contributors may be used to endorse or 
-#		promote products derived from this software without specific prior 
+#
+#	  * Neither the name of the European Space Agency, European Southern
+#		Observatory nor the names of its contributors may be used to endorse or
+#		promote products derived from this software without specific prior
 #		written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY ESA/ESO ``AS IS'' AND ANY EXPRESS OR IMPLIED
 # WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
@@ -36,9 +36,9 @@ import libxmp
 import re
 import time
 import datetime
+import sys
 from dateutil import parser
 
-from libxmp.core import _encode_as_utf8
 from libavm.exceptions import *
 
 
@@ -58,6 +58,37 @@ __all__ = [
 	'AVMDateTime',
 	'AVMDateTimeList',
 ]
+
+
+# This function was removed from libxmp
+# See: https://github.com/python-xmp-toolkit/python-xmp-toolkit/commit/6c1dd6e8ea0cc19da64178da4c5f4c0c1f02a415
+def _encode_as_utf8(obj, input_encoding=None):
+	"""
+    Helper function to ensure that a proper string object in UTF-8 encoding.
+    If obj is not a string, it will try to convert the object into a unicode
+    string and thereafter encode as UTF-8.
+    """
+	# Python 3: unicode is now str, and the is a new bytes type
+	# See: https://python-gtk-3-tutorial.readthedocs.io/en/latest/unicode.html#python-2
+	if sys.version_info[0] >= 3:
+		if isinstance(obj, bytes):
+			return obj.decode()
+		else:
+			return obj
+
+	if sys.hexversion >= 0x03000000:
+		obj = obj.encode()
+		return obj
+
+	if isinstance( obj, unicode ):
+		return obj.encode('utf-8')
+	elif isinstance( obj, str ):
+		if not input_encoding or input_encoding == 'utf-8':
+			return obj
+		else:
+			return obj.decode(input_encoding).encode('utf-8')
+	else:
+		return unicode( obj ).encode('utf-8')
 
 
 class AVMData( object ):
@@ -717,7 +748,7 @@ class AVMOrderedFloatList( AVMOrderedList ):
 					try:
 						float(value)
 						checked_data.append(value)	
-					except Exception, e:
+					except Exception as e:
 						raise TypeError("Enter a string that can be represented as a number.")
 				else:
 					checked_data.append("-")

--- a/libavm/libavm/specs.py
+++ b/libavm/libavm/specs.py
@@ -44,7 +44,14 @@ AVM_SCHEMAS = {
     XMP_NS_IPTCCore: 'Iptc4xmpCore',
     XMP_NS_DC: 'dc',
     XMP_NS_AVM: 'avm',
-    XMP_NS_XMP: 'xmpRights',
+	#####
+	# Disabled when upgrading to Python 3 because it causes:
+	# libxmp.XMPError: Exempi function failure ("unknown error")
+	# When:
+	# xmp = libxmp.XMPMeta()
+	# xmp.register_namespace(XMP_NS_XMP, 'xmpRights')
+	#####
+    # XMP_NS_XMP: 'xmpRights',
     XMP_NS_Photoshop: 'photoshop',
 }
 

--- a/libavm/libavm/specs.py
+++ b/libavm/libavm/specs.py
@@ -44,14 +44,7 @@ AVM_SCHEMAS = {
     XMP_NS_IPTCCore: 'Iptc4xmpCore',
     XMP_NS_DC: 'dc',
     XMP_NS_AVM: 'avm',
-	#####
-	# Disabled when upgrading to Python 3 because it causes:
-	# libxmp.XMPError: Exempi function failure ("unknown error")
-	# When:
-	# xmp = libxmp.XMPMeta()
-	# xmp.register_namespace(XMP_NS_XMP, 'xmpRights')
-	#####
-    # XMP_NS_XMP: 'xmpRights',
+    XMP_NS_XMP_Rights: 'xmpRights',
     XMP_NS_Photoshop: 'photoshop',
 }
 

--- a/libavm/setup.py
+++ b/libavm/setup.py
@@ -43,7 +43,7 @@ import sys
 def read_version():
     try:
         return open('VERSION', 'r').readline().strip()
-    except IOError, e:
+    except IOError as e:
         raise SystemExit(
             "Error: you must run setup from the root directory (%s)" % str(e))
 
@@ -58,4 +58,9 @@ setup(
 	long_description='A module for parsing, manipulating, and serializing Astronomy Visualization Metadata in the XMP format. ',
 	license='New BSD License',
 	packages=['libavm'],
+	install_requires=[
+		# python-xmp-toolkit == 2.0.1 or newer is required when using Python 3
+		'python-xmp-toolkit',
+		'future'
+	]
 )

--- a/libavm/test/samples.py
+++ b/libavm/test/samples.py
@@ -94,5 +94,5 @@ def remove_temp_samples():
 	global sampledir
 	if os.path.exists( sampledir ):
 		if not os.path.isdir( sampledir):
-			raise StandardError('Cannot remove .tempsamples - it is not a directory. Please manually remove it.')
+			raise Exception('Cannot remove .tempsamples - it is not a directory. Please manually remove it.')
 		shutil.rmtree( sampledir )

--- a/libavm/test/test_utils.py
+++ b/libavm/test/test_utils.py
@@ -29,6 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE
 
+from __future__ import print_function
 import unittest
 
 import sys
@@ -119,7 +120,7 @@ class AVMUtilsTestCase(unittest.TestCase):
         
     def test_avm_to_file(self):
         for f in samplefiles.iteritems():
-            print f[0]
+            print(f[0])
             avm_to_file(f[0], self.avm_dict, replace=True)
             retrieved_avm = avm_from_file(f[0])
             self.assertEqual(retrieved_avm, self.avm_dict, f[0])


### PR DESCRIPTION
The `XMP_NS_XMP` was wrong and causing:

```
libxmp.XMPError: Exempi function failure ("unknown error")
```

When registering it:
```
xmp.register_namespace(XMP_NS_XMP, 'xmpRights')
```

Now, it's solved by using `XMP_NS_XMP_Rights`